### PR TITLE
[Feat] build support on mac silicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ tags
 compile_commands.json
 repack/*
 tests/tmp.tcl
+
+src/data.rocks/*

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ git submodule upadate --init
 cd redis
 make
 ```
+* Tips: Macos silicon chips users plz refer to [manual](build_support_on_mac_silicon/build_support_on_mac_silicon_manual.md)
 
 ## Details
 

--- a/build_support_on_mac_silicon/build_support_on_mac_silicon_manual.md
+++ b/build_support_on_mac_silicon/build_support_on_mac_silicon_manual.md
@@ -1,0 +1,33 @@
+# ROR Build On Mac Silicon Manual
+
+## Pre-Requirement
+1. Install and configure snappy and bzip.
+    ```bash
+    # example for homebrew
+    brew install snappy bzip2
+    ```
+
+## Git Pull Submodules
+1. Clone submodules like below.
+2. Tips:
+   1. ROR relys on Rocksdb function `rocksdb_options_add_compact_on_deletion_collector_factory(rocksdb_options_t*, size_t window_size, size_t num_dels_trigger, double deletion_ratio);` (deps/rocksdb/include/rocksdb/c.h) which is modified in later version, so **REMEMBER TO REVERT TO A QUALIFIED VERSION TO MATCH THE CALLER**.
+    ```bash
+    # Following steps are all executed at Redis-On-Rocks dir
+    $ git submodule update --init --recursive
+    $ cd deps/rocksdb && git checkout 05df30a856d9b9baf8dbd8396722558d7f07aac9
+
+    # Following is my version of submodule
+    $ git submodule status
+    071c33846d576edc1e59d26b1199eba968e71ca2 deps/rocksdb (blob_st_lvl-pre-621-g071c33846)
+    456989ff7c9a601a88a7dd14d32789b266dc6fc7 deps/xredis-gtid (heads/master)
+
+    # Apply ./build_support_on_mac_silicon/rocksdb.patch to deps/rocksdb
+    $ cp ./build_support_on_mac_silicon/rocksdb.patch ./deps/rocksdb && cd deps/rocksdb && git apply ./rocksdb.patch
+    ```
+
+## Begin to Build
+1. Now you can build like following
+   ```bash
+   # cd Redis-On-Rocks dir
+   $ make
+   ```

--- a/build_support_on_mac_silicon/rocksdb.patch
+++ b/build_support_on_mac_silicon/rocksdb.patch
@@ -1,0 +1,17 @@
+diff --git a/Makefile b/Makefile
+index 0b507b591..24fd4bb05 100644
+--- a/Makefile
++++ b/Makefile
+@@ -565,9 +565,9 @@ ifeq ($(PLATFORM), OS_OPENBSD)
+ 	WARNING_FLAGS += -Wno-unused-lambda-capture
+ endif
+ 
+-ifndef DISABLE_WARNING_AS_ERROR
+-	WARNING_FLAGS += -Werror
+-endif
++# ifndef DISABLE_WARNING_AS_ERROR
++# WARNING_FLAGS += -Werror
++# endif
+ 
+ 
+ ifdef LUA_PATH

--- a/src/Makefile
+++ b/src/Makefile
@@ -111,7 +111,11 @@ endif
 
 FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(REDIS_CFLAGS)
 FINAL_LDFLAGS=$(LDFLAGS) $(REDIS_LDFLAGS) $(DEBUG)
+ifeq ($(shell uname),Darwin)
+FINAL_LIBS=-lm -lstdc++ -pthread -lsnappy -lz
+else
 FINAL_LIBS=-lm -lrt -lstdc++ -pthread -lsnappy -lz
+endif
 DEBUG=-g -ggdb -fno-omit-frame-pointer
 
 # Linux ARM32 needs -latomic at linking time

--- a/src/config.h
+++ b/src/config.h
@@ -39,10 +39,14 @@
 #include <fcntl.h>
 #endif
 
+#if defined(__APPLE__) && defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+#define MAC_OS_10_6_DETECTED
+#endif
+
 /* Define redis_fstat to fstat or fstat64() */
-#if defined(__APPLE__) && !defined(MAC_OS_X_VERSION_10_6)
-#define redis_fstat fstat64
-#define redis_stat stat64
+#if defined(__APPLE__) && !defined(MAC_OS_10_6_DETECTED)
+#define redis_fstat fstat
+#define redis_stat stat
 #else
 #define redis_fstat fstat
 #define redis_stat stat
@@ -64,8 +68,8 @@
 
 /* Test for backtrace() */
 #if defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__)) || \
-    defined(__FreeBSD__) || ((defined(__OpenBSD__) || defined(__NetBSD__)) && defined(USE_BACKTRACE))\
- || defined(__DragonFly__) || (defined(__UCLIBC__) && defined(__UCLIBC_HAS_BACKTRACE__))
+defined(__FreeBSD__) || ((defined(__OpenBSD__) || defined(__NetBSD__)) && defined(USE_BACKTRACE))\
+|| defined(__DragonFly__) || (defined(__UCLIBC__) && defined(__UCLIBC_HAS_BACKTRACE__))
 #define HAVE_BACKTRACE 1
 #endif
 
@@ -79,7 +83,7 @@
 #define HAVE_EPOLL 1
 #endif
 
-#if (defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_6)) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined (__NetBSD__)
+#if (defined(__APPLE__) && defined(MAC_OS_10_6_DETECTED)) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined (__NetBSD__)
 #define HAVE_KQUEUE 1
 #endif
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -1068,7 +1068,7 @@ void bugReportStart(void) {
 
 #ifdef HAVE_BACKTRACE
 static void *getMcontextEip(ucontext_t *uc) {
-#if defined(__APPLE__) && !defined(MAC_OS_X_VERSION_10_6)
+#if defined(__APPLE__) && !defined(MAC_OS_10_6_DETECTED)
     /* OSX < 10.6 */
     #if defined(__x86_64__)
     return (void*) uc->uc_mcontext->__ss.__rip;
@@ -1077,7 +1077,7 @@ static void *getMcontextEip(ucontext_t *uc) {
     #else
     return (void*) uc->uc_mcontext->__ss.__srr0;
     #endif
-#elif defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_6)
+#elif defined(__APPLE__) && defined(MAC_OS_10_6_DETECTED)
     /* OSX >= 10.6 */
     #if defined(_STRUCT_X86_THREAD_STATE64) && !defined(__i386__)
     return (void*) uc->uc_mcontext->__ss.__rip;
@@ -1146,7 +1146,7 @@ void logRegisters(ucontext_t *uc) {
     serverLog(LL_WARNING|LL_RAW, "\n------ REGISTERS ------\n");
 
 /* OSX */
-#if defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_6)
+#if defined(__APPLE__) && defined(MAC_OS_10_6_DETECTED)
   /* OSX AMD64 */
     #if defined(_STRUCT_X86_THREAD_STATE64) && !defined(__i386__)
     serverLog(LL_WARNING,


### PR DESCRIPTION
[Feat] build support on mac silicon
1. Feature: Support ror build on mac silicon chips
2. For details docs, plz refer to doc [manual](https://github.com/adzfolc/Redis-On-Rocks/blob/build_support_mac_silicon/build_support_on_mac_silicon/build_support_on_mac_silicon_manual.md).
3. Modifications:
   1. add src/data.rocks/* to .gitignore
   2. add build_support_on_mac_silicon_manual to README.md
   3. add build_support_on_mac_silicon_manual.md build doc
   4. add rocksdb modification patch
   5. modify src/Makefile, src/config.h, src/debug.c to adapt to Mac Silicon Chips.