### PR TITLE
[Feat] build support on mac silicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ tags
 compile_commands.json
 repack/*
 tests/tmp.tcl
+
+src/data.rocks/*

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ yum install snappy-devel zlib-devel gflags-devel libstdc++
 
 ```
 git clone https://github.com/ctripcorp/Redis-On-Rocks.git
-git submodule upadate --init
+git submodule update --init
 cd redis
 make
 ```

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -94,9 +94,14 @@ jemalloc: .make-prerequisites
 
 .PHONY: jemalloc
 
+# -Wno-unused-but-set-variable: meaning do not report warning when meeting unused but set variable
+# -Wno-error: meaning do not report error when meeting warnings
+CFLAGS += -Wno-unused-but-set-variable -Wno-error
+ROCKSDB_CFLAGS = $(CFLAGS)
+
 rocksdb: .make-prerequisites
 	@printf '%b %b\n' $(MAKECOLOR)MAKE$(ENDCOLOR) $(BINCOLOR)$@$(ENDCOLOR)
-	cd rocksdb && ROCKSDB_DISABLE_BZIP=1 ROCKSDB_DISABLE_LZ4=1 ROCKSDB_DISABLE_ZSTD=1 ROCKSDB_DISABLE_MALLOC_USABLE_SIZE=1 ROCKSDB_DISABLE_MEMKIND=1 PORTABLE=1 $(MAKE) static_lib
+	cd rocksdb && ROCKSDB_DISABLE_BZIP=1 ROCKSDB_DISABLE_LZ4=1 ROCKSDB_DISABLE_ZSTD=1 ROCKSDB_DISABLE_MALLOC_USABLE_SIZE=1 ROCKSDB_DISABLE_MEMKIND=1 PORTABLE=1 $(MAKE) CFLAGS="$(ROCKSDB_CFLAGS)" static_lib
 
 .PHONY: rocksdb
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -111,7 +111,7 @@ endif
 
 FINAL_CFLAGS=$(STD) $(WARN) $(OPT) $(DEBUG) $(CFLAGS) $(REDIS_CFLAGS)
 FINAL_LDFLAGS=$(LDFLAGS) $(REDIS_LDFLAGS) $(DEBUG)
-FINAL_LIBS=-lm -lrt -lstdc++ -pthread -lsnappy -lz
+FINAL_LIBS=-lm -lstdc++ -pthread -lsnappy -lz
 DEBUG=-g -ggdb -fno-omit-frame-pointer
 
 # Linux ARM32 needs -latomic at linking time

--- a/src/config.h
+++ b/src/config.h
@@ -39,8 +39,18 @@
 #include <fcntl.h>
 #endif
 
+#if defined(__APPLE__) && defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+#define MAC_OS_10_6_DETECTED
+#endif
+
+/**
+ * Please refer to https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/stat.2.html for more details.
+ * HISTORY
+     An lstat() function call appeared in 4.2BSD.  The stat64(), fstat64(),
+     and lstat64() system calls first appeared in Mac OS X 10.5 (Leopard).
+ */
 /* Define redis_fstat to fstat or fstat64() */
-#if defined(__APPLE__) && !defined(MAC_OS_X_VERSION_10_6)
+#if defined(__APPLE__) && !defined(MAC_OS_10_6_DETECTED)
 #define redis_fstat fstat64
 #define redis_stat stat64
 #else
@@ -79,7 +89,7 @@
 #define HAVE_EPOLL 1
 #endif
 
-#if (defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_6)) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined (__NetBSD__)
+#if (defined(__APPLE__) && defined(MAC_OS_10_6_DETECTED)) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined (__NetBSD__)
 #define HAVE_KQUEUE 1
 #endif
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -1068,7 +1068,7 @@ void bugReportStart(void) {
 
 #ifdef HAVE_BACKTRACE
 static void *getMcontextEip(ucontext_t *uc) {
-#if defined(__APPLE__) && !defined(MAC_OS_X_VERSION_10_6)
+#if defined(__APPLE__) && !defined(MAC_OS_10_6_DETECTED)
     /* OSX < 10.6 */
     #if defined(__x86_64__)
     return (void*) uc->uc_mcontext->__ss.__rip;
@@ -1077,7 +1077,7 @@ static void *getMcontextEip(ucontext_t *uc) {
     #else
     return (void*) uc->uc_mcontext->__ss.__srr0;
     #endif
-#elif defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_6)
+#elif defined(__APPLE__) && defined(MAC_OS_10_6_DETECTED)
     /* OSX >= 10.6 */
     #if defined(_STRUCT_X86_THREAD_STATE64) && !defined(__i386__)
     return (void*) uc->uc_mcontext->__ss.__rip;
@@ -1146,7 +1146,7 @@ void logRegisters(ucontext_t *uc) {
     serverLog(LL_WARNING|LL_RAW, "\n------ REGISTERS ------\n");
 
 /* OSX */
-#if defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_6)
+#if defined(__APPLE__) && defined(MAC_OS_10_6_DETECTED)
   /* OSX AMD64 */
     #if defined(_STRUCT_X86_THREAD_STATE64) && !defined(__i386__)
     serverLog(LL_WARNING,


### PR DESCRIPTION
[Fix]
1. fix typo in `README.md`.

[Feat]
1. Add `src/data.rocks/*` to .gitignore.
2. Add `-Wno-error -Wno-unused-but-set-variable` as CFLAGS to `deps/Makefile`
   1. `-Wno-error`: In GCC, it prevents to regard build warnings as build errors
   2. `-Wno-unused-but-set-variable`: In GCC, it prevents to report warning when meeting unused but set variable.
3. Modify `src/Makefile`, `src/config.h`, `src/debug.c` to adapt to Darwin env and others.