### PR TITLE
[Fix] fix memory leak && data race

### DIFF
--- a/src/ctrip_swap.h
+++ b/src/ctrip_swap.h
@@ -848,13 +848,8 @@ int swapDataSetupHash(swapData *d, OUT void **datactx);
 #define createHashObjectMeta(version, len) createLenObjectMeta(OBJ_HASH, version, len)
 
 /* String */
-typedef struct wholeKeyDataCtx {
-    int ctx_flag;
-} wholeKeyDataCtx;
-
 typedef struct wholeKeySwapData {
   swapData d;
-  wholeKeyDataCtx ctx[1]; 
 } wholeKeySwapData;
 
 int swapDataSetupWholeKey(swapData *d, OUT void **datactx);
@@ -1645,7 +1640,9 @@ static inline unsigned long ctirp_evictionTimeLimitUs(void) {
 /* used memory in disk swap mode */
 size_t coldFiltersUsedMemory(void); /* cuckoo filter not counted in maxmemory */
 static inline size_t ctrip_getUsedMemory(void) {
-    return zmalloc_used_memory() - server.swap_inprogress_memory -
+  int swap_inprogress_memory;
+  atomicGet(server.swap_inprogress_memory, swap_inprogress_memory);
+  return zmalloc_used_memory() - swap_inprogress_memory -
       coldFiltersUsedMemory() - swapPersistCtxUsedMemory(server.swap_persist_ctx);
 }
 static inline int ctrip_evictionTimeProcGetDelayMillis(void) {


### PR DESCRIPTION
1. asan error: memory leak
```
[[0;32;49mok[0m]: [SETEX] OVERWRITE TO STRING - hash
[[0;31;49merr[0m]: Sanitizer error: 
=================================================================
==455232==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 23032 byte(s) in 5758 object(s) allocated from:
    #0 0xffff7f1fa2f4 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0xaaaad868786c in ztrymalloc_usable /home/ubuntu/Workspace/Redis-On-Rocks/src/zmalloc.c:101
    #2 0xaaaad868786c in zmalloc /home/ubuntu/Workspace/Redis-On-Rocks/src/zmalloc.c:119
    #3 0xaaaad88908a0 in swapDataSetupWholeKey /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_string.c:295
    #4 0xaaaad881c470 in keyRequestProceed /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap.c:413
    #5 0xaaaad888d874 in lockProceedIfReady /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_lock.c:589
    #6 0xaaaad888d874 in _lockLock /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_lock.c:639
    #7 0xaaaad888e448 in lockLock /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_lock.c:649
    #8 0xaaaad881da64 in _submitClientKeyRequests /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap.c:502
    #9 0xaaaad8831c70 in submitEvictClientRequest /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_evict.c:68
    #10 0xaaaad8831f68 in tryEvictKey /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_evict.c:96
    #11 0xaaaad8832194 in swapEvictCommand /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_evict.c:118
    #12 0xaaaad8673214 in call /home/ubuntu/Workspace/Redis-On-Rocks/src/server.c:4051
    #13 0xaaaad881e538 in dbSwap /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap.c:591
    #14 0xaaaad8676a1c in processCommand /home/ubuntu/Workspace/Redis-On-Rocks/src/server.c:4615
    #15 0xaaaad86a26f8 in processCommandAndResetClient /home/ubuntu/Workspace/Redis-On-Rocks/src/networking.c:2188
    #16 0xaaaad86a26f8 in processInputBuffer /home/ubuntu/Workspace/Redis-On-Rocks/src/networking.c:2292
    #17 0xaaaad881813c in callHandler /home/ubuntu/Workspace/Redis-On-Rocks/src/connhelpers.h:79
    #18 0xaaaad881813c in connSocketEventHandler /home/ubuntu/Workspace/Redis-On-Rocks/src/connection.c:295
    #19 0xaaaad8661f20 in aeProcessEvents /home/ubuntu/Workspace/Redis-On-Rocks/src/ae.c:427
    #20 0xaaaad8662b18 in aeMain /home/ubuntu/Workspace/Redis-On-Rocks/src/ae.c:487
    #21 0xaaaad8639cec in main /home/ubuntu/Workspace/Redis-On-Rocks/src/server.c:6853
    #22 0xffff7ec773f8 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #23 0xffff7ec774c8 in __libc_start_main_impl ../csu/libc-start.c:392
    #24 0xaaaad865886c in _start (/home/ubuntu/Workspace/Redis-On-Rocks/src/redis-server+0x26886c)

Direct leak of 23028 byte(s) in 5757 object(s) allocated from:
    #0 0xffff7f1fa2f4 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0xaaaad868786c in ztrymalloc_usable /home/ubuntu/Workspace/Redis-On-Rocks/src/zmalloc.c:101
    #2 0xaaaad868786c in zmalloc /home/ubuntu/Workspace/Redis-On-Rocks/src/zmalloc.c:119
    #3 0xaaaad88908a0 in swapDataSetupWholeKey /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_string.c:295
    #4 0xaaaad882debc in swapDataDecodeAndSetupMeta /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_data.c:373
    #5 0xaaaad883a340 in swapExecBatchPreprocess /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_exec.c:770
    #6 0xaaaad88222e8 in swapRequestBatchPreprocess /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_batch.c:246
    #7 0xaaaad88223a8 in swapRequestBatchProcess /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_batch.c:254
    #8 0xaaaad8886784 in swapThreadMain /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_thread.c:60
    #9 0xffff7eccd5c4 in start_thread nptl/pthread_create.c:442
    #10 0xffff7ed35ed8  (/lib/aarch64-linux-gnu/libc.so.6+0xe5ed8)

Direct leak of 1168 byte(s) in 292 object(s) allocated from:
    #0 0xffff7f1fa2f4 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0xaaaad868786c in ztrymalloc_usable /home/ubuntu/Workspace/Redis-On-Rocks/src/zmalloc.c:101
    #2 0xaaaad868786c in zmalloc /home/ubuntu/Workspace/Redis-On-Rocks/src/zmalloc.c:119
    #3 0xaaaad88908a0 in swapDataSetupWholeKey /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_string.c:295
    #4 0xaaaad881c470 in keyRequestProceed /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap.c:413
    #5 0xaaaad888d874 in lockProceedIfReady /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_lock.c:589
    #6 0xaaaad888d874 in _lockLock /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_lock.c:639
    #7 0xaaaad888e448 in lockLock /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_lock.c:649
    #8 0xaaaad881da64 in _submitClientKeyRequests /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap.c:502
    #9 0xaaaad881de00 in submitClientKeyRequests /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap.c:514
    #10 0xaaaad881de00 in submitNormalClientRequests /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap.c:528
    #11 0xaaaad881e524 in dbSwap /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap.c:567
    #12 0xaaaad8676a1c in processCommand /home/ubuntu/Workspace/Redis-On-Rocks/src/server.c:4615
    #13 0xaaaad86a26f8 in processCommandAndResetClient /home/ubuntu/Workspace/Redis-On-Rocks/src/networking.c:2188
    #14 0xaaaad86a26f8 in processInputBuffer /home/ubuntu/Workspace/Redis-On-Rocks/src/networking.c:2292
    #15 0xaaaad881813c in callHandler /home/ubuntu/Workspace/Redis-On-Rocks/src/connhelpers.h:79
    #16 0xaaaad881813c in connSocketEventHandler /home/ubuntu/Workspace/Redis-On-Rocks/src/connection.c:295
    #17 0xaaaad8661f20 in aeProcessEvents /home/ubuntu/Workspace/Redis-On-Rocks/src/ae.c:427
    #18 0xaaaad8662b18 in aeMain /home/ubuntu/Workspace/Redis-On-Rocks/src/ae.c:487
    #19 0xaaaad8639cec in main /home/ubuntu/Workspace/Redis-On-Rocks/src/server.c:6853
    #20 0xffff7ec773f8 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #21 0xffff7ec774c8 in __libc_start_main_impl ../csu/libc-start.c:392
    #22 0xaaaad865886c in _start (/home/ubuntu/Workspace/Redis-On-Rocks/src/redis-server+0x26886c)

SUMMARY: AddressSanitizer: 47228 byte(s) leaked in 11807 allocation(s).
```

2. tsan error: data race
```
ThreadSanitizer: reported 7 warnings

[2/99 [0;33;49mdone[0m]: swap/integration/type_error (9 seconds)
[1;37;49mTesting swap/ported/stream-cgroups[0m
[[0;31;49merr[0m]: Sanitizer error: ==================
WARNING: ThreadSanitizer: data race (pid=493421)
  Read of size 8 at 0xaaaaab48ac48 by main thread (mutexes: write M850):
    #0 ctrip_getUsedMemory /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap.h:1648 (redis-server+0x3829c8)
    #1 swapPersistGetUsedMemory /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_persist.c:300 (redis-server+0x3829c8)
    #2 swapPersistCtxPersistKeysStart /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_persist.c:318 (redis-server+0x382f94)
    #3 swapPersistCtxPersistKeys /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_persist.c:336 (redis-server+0x382f94)
    #4 call /home/ubuntu/Workspace/Redis-On-Rocks/src/server.c:4242 (redis-server+0x213c58)
    #5 continueProcessCommand /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap.c:243 (redis-server+0x32e9f8)
    #6 normalClientKeyRequestFinished /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap.c:282 (redis-server+0x32eb54)
    #7 keyRequestSwapFinished /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap.c:303 (redis-server+0x32e0d8)
    #8 keyRequestProceed /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap.c:476 (redis-server+0x32e0d8)
    #9 lockProceed /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_lock.c:539 (redis-server+0x37319c)
    #10 lockProceedIfReady /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_lock.c:589 (redis-server+0x374698)
    #11 _lockLock /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_lock.c:639 (redis-server+0x374698)
    #12 lockLock /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_lock.c:649 (redis-server+0x374de0)
    #13 _submitClientKeyRequests /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap.c:502 (redis-server+0x32ee58)
    #14 submitClientKeyRequests /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap.c:514 (redis-server+0x32f0a8)
    #15 submitNormalClientRequests /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap.c:528 (redis-server+0x32f0a8)
    #16 dbSwap /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap.c:567 (redis-server+0x32f534)
    #17 processCommand /home/ubuntu/Workspace/Redis-On-Rocks/src/server.c:4615 (redis-server+0x2167cc)
    #18 processCommandAndResetClient /home/ubuntu/Workspace/Redis-On-Rocks/src/networking.c:2188 (redis-server+0x234798)
    #19 processInputBuffer /home/ubuntu/Workspace/Redis-On-Rocks/src/networking.c:2292 (redis-server+0x234798)
    #20 readQueryFromClient /home/ubuntu/Workspace/Redis-On-Rocks/src/networking.c:2382 (redis-server+0x23986c)
    #21 callHandler /home/ubuntu/Workspace/Redis-On-Rocks/src/connhelpers.h:79 (redis-server+0x32b07c)
    #22 connSocketEventHandler /home/ubuntu/Workspace/Redis-On-Rocks/src/connection.c:295 (redis-server+0x32b07c)
    #23 aeProcessEvents /home/ubuntu/Workspace/Redis-On-Rocks/src/ae.c:427 (redis-server+0x205a58)
    #24 aeMain /home/ubuntu/Workspace/Redis-On-Rocks/src/ae.c:487 (redis-server+0x206088)
    #25 main /home/ubuntu/Workspace/Redis-On-Rocks/src/server.c:6853 (redis-server+0x1e1334)

  Previous atomic write of size 8 at 0xaaaaab48ac48 by thread T27:
    #0 __tsan_atomic64_fetch_add ../../../../src/libsanitizer/tsan/tsan_interface_atomic.cpp:620 (libtsan.so.0+0x86e24)
    #1 swapExecBatchUpdateStatsRIOBatch /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_exec.c:308 (redis-server+0x33ec64)
    #2 swapExecBatchUpdateStatsRIOBatch /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_exec.c:297 (redis-server+0x33ec64)
    #3 swapExecBatchExecuteOut /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_exec.c:636 (redis-server+0x340a38)
    #4 swapExecBatchExecute /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_exec.c:718 (redis-server+0x340f40)
    #5 swapExecBatchCtxExecuteIfNeeded /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_batch.c:70 (redis-server+0x331aa4)
    #6 swapExecBatchCtxEnd /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_batch.c:110 (redis-server+0x331aa4)
    #7 swapRequestBatchExecute /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_batch.c:229 (redis-server+0x331aa4)
    #8 swapRequestBatchProcess /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_batch.c:255 (redis-server+0x331ce0)
    #9 swapThreadMain /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_thread.c:60 (redis-server+0x36ff8c)

  Location is global 'server' of size 16912 at 0xaaaaab486dd0 (redis-server+0x0000009eac48)

  Mutex M850 (0xaaaaab4a6588) created at:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4240 (libtsan.so.0+0x56880)
    #1 moduleInitModulesSystem /home/ubuntu/Workspace/Redis-On-Rocks/src/module.c:8621 (redis-server+0x2fff64)
    #2 main /home/ubuntu/Workspace/Redis-On-Rocks/src/server.c:6679 (redis-server+0x1e0fb0)

  Thread T27 'swap_thd_4' (tid=493498, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:969 (libtsan.so.0+0x63bb0)
    #1 swapThreadsInit /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap_thread.c:83 (redis-server+0x3701bc)
    #2 InitServerLast /home/ubuntu/Workspace/Redis-On-Rocks/src/server.c:3688 (redis-server+0x211460)
    #3 main /home/ubuntu/Workspace/Redis-On-Rocks/src/server.c:6813 (redis-server+0x1e1270)

SUMMARY: ThreadSanitizer: data race /home/ubuntu/Workspace/Redis-On-Rocks/src/ctrip_swap.h:1648 in ctrip_getUsedMemory
```
