### PR TITLE
doc: compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,21 +49,35 @@ Redis can be the slave of ror by directly executing the slaveof command. ROR rep
     * libstdc++
 
 3. Compilation Process
-    * 3.1 Get the source code
+    * 3.1 Install Library
+    ```bash
+    # GCC versions among (gcc-9, gcc-10, gcc-11, gcc-13) are well supported.
+    # WARNING: gcc-12 is not supported, for bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115824
+
+    # for Ubuntu/Debian
+    sudo apt update
+    sudo apt install -y build-essential libsnappy-dev libsnappy1v5 pkg-config zlib1g zlib1g-dev
+
+    # for CentOS/RHEL
+    sudo yum install -y zlib-devel-1.2.11 snappy-devel-1.1.8 jemalloc-5.2.1 procps-ng-3.3.17
+
+    # for Mac
+    # Ensure Homebrew is installed
+    # /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    # Install required packages
+    brew install libsnappy pkg-config zlib
+    ```
+    * 3.2 Get the source code
     ```bash
     git clone https://github.com/ctripcorp/Redis-On-Rocks/
     ```
-    * 3.2 Switch to the latest release version
+    * 3.3 Switch to the latest release version
     ```bash
     git tag          # Check the latest release tag (e.g., ror-1.2.4)
     git checkout TAG # Switch to the latest version (e.g., git checkout ror-1.2.4)
     ```
-    * 3.3 Execute compilation
+    * 3.4 Execute compilation
     ```bash
-    yum install -y zlib-devel-1.2.11  \
-        snappy-devel-1.1.8  \
-        jemalloc-5.2.1  \
-        procps-ng-3.3.17
     cd Redis-On-Rocks
     git submodule update --init --recursive
     make


### PR DESCRIPTION
PR in brief
1. add `DISABLE_WARNING_AS_ERROR=1` to prevent error following
```
db/db_impl/db_impl.cc: In member function ‘virtual rocksdb::Status rocksdb::DBImpl::FlushWAL(bool)’:
db/db_impl/db_impl.cc:1441:23: error: redundant move in return statement [-Werror=redundant-move]
 1441 |       return std::move(io_s);
      |              ~~~~~~~~~^~~~~~
db/db_impl/db_impl.cc:1441:23: note: remove ‘std::move’ call
db/db_impl/db_impl.cc:1445:23: error: redundant move in return statement [-Werror=redundant-move]
 1445 |       return std::move(io_s);
      |              ~~~~~~~~~^~~~~~
db/db_impl/db_impl.cc:1445:23: note: remove ‘std::move’ call
db/db_impl/db_impl.cc: In member function ‘virtual rocksdb::Status rocksdb::DBImpl::LockWAL()’:
db/db_impl/db_impl.cc:1562:19: error: redundant move in return statement [-Werror=redundant-move]
 1562 |   return std::move(status);
```
2. add env set up(gcc, lib, cflags) info 