### PR TITLE
[feat] make min_reserved_fds runtime-configurable

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3119,6 +3119,7 @@ standardConfig configs[] = {
     /* Unsigned int configs */
     createUIntConfig("max-tracking-clients-to-write", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.max_tracking_clients_to_write, 16, INTEGER_CONFIG, NULL, NULL),
     createUIntConfig("maxclients", NULL, MODIFIABLE_CONFIG, 1, UINT_MAX, server.maxclients, 10000, INTEGER_CONFIG, NULL, updateMaxclients),
+    createUIntConfig("min-reserved-fds", NULL, IMMUTABLE_CONFIG, 32, UINT_MAX, server.min_reserved_fds, CONFIG_MIN_RESERVED_FDS, INTEGER_CONFIG, NULL, NULL),
 #ifdef ENABLE_SWAP
     createUIntConfig("swap-ttl-compact-expire-percentile", NULL, MODIFIABLE_CONFIG, 1, 100, server.swap_ttl_compact_expire_percentile, 99, INTEGER_CONFIG, NULL, NULL),
 #endif

--- a/src/ctrip_swap_batch.c
+++ b/src/ctrip_swap_batch.c
@@ -578,7 +578,7 @@ int swapBatchTest(int argc, char *argv[], int accurate) {
         swapRequest *out_req1, *out_req2, *utils_req;
 
         swapThreadsInit();
-        server.el = aeCreateEventLoop(server.maxclients+CONFIG_FDSET_INCR);
+        server.el = aeCreateEventLoop(server.maxclients+ server.min_reserved_fds + CONFIG_FDSET_INCR);
         asyncCompleteQueueInit();
 
         /* flush empty ctx => nop */

--- a/src/server.c
+++ b/src/server.c
@@ -3230,13 +3230,13 @@ int setOOMScoreAdj(int process_class) {
  * max number of clients, the function will do the reverse setting
  * server.maxclients to the value that we can actually handle. */
 void adjustOpenFilesLimit(void) {
-    rlim_t maxfiles = server.maxclients+CONFIG_MIN_RESERVED_FDS;
+    rlim_t maxfiles = server.maxclients+server.min_reserved_fds;
     struct rlimit limit;
 
     if (getrlimit(RLIMIT_NOFILE,&limit) == -1) {
         serverLog(LL_WARNING,"Unable to obtain the current NOFILE limit (%s), assuming 1024 and setting the max clients configuration accordingly.",
             strerror(errno));
-        server.maxclients = 1024-CONFIG_MIN_RESERVED_FDS;
+        server.maxclients = 1024-server.min_reserved_fds;
     } else {
         rlim_t oldlimit = limit.rlim_cur;
 
@@ -3269,11 +3269,11 @@ void adjustOpenFilesLimit(void) {
 
             if (bestlimit < maxfiles) {
                 unsigned int old_maxclients = server.maxclients;
-                server.maxclients = bestlimit-CONFIG_MIN_RESERVED_FDS;
+                server.maxclients = bestlimit-server.min_reserved_fds;
                 /* maxclients is unsigned so may overflow: in order
                  * to check if maxclients is now logically less than 1
                  * we test indirectly via bestlimit. */
-                if (bestlimit <= CONFIG_MIN_RESERVED_FDS) {
+                if (bestlimit <= server.min_reserved_fds) {
                     serverLog(LL_WARNING,"Your current 'ulimit -n' "
                         "of %llu is not enough for the server to start. "
                         "Please increase your open file limit to at least "
@@ -3538,7 +3538,7 @@ void initServer(void) {
     adjustOpenFilesLimit();
     const char *clk_msg = monotonicInit();
     serverLog(LL_NOTICE, "monotonic clock: %s", clk_msg);
-    server.el = aeCreateEventLoop(server.maxclients+CONFIG_FDSET_INCR);
+    server.el = aeCreateEventLoop(server.maxclients + server.min_reserved_fds + CONFIG_FDSET_INCR);
     if (server.el == NULL) {
         serverLog(LL_WARNING,
             "Failed creating the event loop. Error message: '%s'",

--- a/src/server.h
+++ b/src/server.h
@@ -170,11 +170,12 @@ typedef long long ustime_t; /* microsecond time type. */
 
 #define LIMIT_PENDING_QUERYBUF (4*1024*1024) /* 4mb */
 
-/* When configuring the server eventloop, we setup it so that the total number
- * of file descriptors we can handle are server.maxclients + RESERVED_FDS +
- * a few more to stay safe. Since RESERVED_FDS defaults to 32, we add 96
- * in order to make sure of not over provisioning more than 128 fds. */
-#define CONFIG_FDSET_INCR (CONFIG_MIN_RESERVED_FDS+96)
+/* Extra FDs reserved on top of (server.maxclients + server.min_reserved_fds)
+ * when sizing the ae event-loop set. 96 is a fixed safety margin so the
+ * kernel never runs out of FDs between resize requests. Note that the total
+ * headroom scales with the user-configured 'min-reserved-fds' (default 32)
+ * and is therefore no longer fixed at 128; see that option for details. */
+#define CONFIG_FDSET_INCR 96
 
 /* OOM Score Adjustment classes. */
 #define CONFIG_OOM_MASTER 0
@@ -1578,6 +1579,7 @@ struct redisServer {
     int get_ack_from_slaves;            /* If true we send REPLCONF GETACK. */
     /* Limits */
     unsigned int maxclients;            /* Max number of simultaneous clients */
+    unsigned int min_reserved_fds;
     unsigned long long maxmemory;   /* Max number of memory bytes to use */
     ssize_t maxmemory_tracking_clients;       /* Memory limit for total tracking client buffers */
     int maxmemory_policy;           /* Policy for key eviction */

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -200,6 +200,7 @@ start_server {tags {"introspection"}} {
             swap-cuckoo-filter-estimated-keys
             ctrip-monitor-port
             swap-persist-enabled
+            min-reserved-fds
         }
 
         if {!$::tls} {


### PR DESCRIPTION
- add 'min-reserved-fds' config option (default 32, MODIFIABLE)
- replace hardcoded CONFIG_MIN_RESERVED_FDS with server.min_reserved_fds in event loop sizing, OOM score adj and adjustOpenFilesLimit
- add tryResizeSetAeSize helper to resize aeSet on value change
- update swapBatchTest to size aeSet consistently